### PR TITLE
Add gitignores to ignored globs

### DIFF
--- a/codeselect.py
+++ b/codeselect.py
@@ -23,7 +23,21 @@ __version__ = "1.0.0"
 
 
 def read_non_comments(path: Path) -> list[str]:
-    """Read non-empty non-comment lines from that path"""
+    """Read non-empty non-comment lines from that path
+
+    Read all lines from this source file
+    >>> my_lines = read_non_comments(Path(__file__))
+
+    This function's def should be one of the lines
+    >>> assert 'def read_non_comments(path: Path) -> list[str]:' in my_lines
+
+    The comment below should be excluded
+    >>> assert '# A comment' not in my_lines
+
+    Empty lines should be excluded
+    >>> assert all([_ for _ in my_lines])
+    """
+# A comment
     if not path.is_file():
         return []
     all_lines = path.read_text().splitlines()
@@ -31,7 +45,19 @@ def read_non_comments(path: Path) -> list[str]:
 
 
 def read_globs(path: Path, base_patterns: list[str]) -> list[str]:
-    """Strip any '/' used for dirs in the lines at that path"""
+    """Strip any '/' used for dirs in the lines at that path
+
+    Ignore the base patterns
+
+    >>> base_patterns = []
+    >>> assert '    Ignore the base patterns' in read_globs(Path(__file__), base_patterns)
+    >>> base_patterns = ['    Ignore the base patterns']
+    >>> assert '    Ignore the base patterns' not in read_globs(Path(__file__), base_patterns)
+
+    This line ends with /
+        and the '/' should be removed
+    >>> assert '    This line ends with ' in read_globs(Path(__file__), [])
+    """
     lines = read_non_comments(path)
     return [_.rstrip('/') for _ in lines if _ not in base_patterns]
 

--- a/codeselect.py
+++ b/codeselect.py
@@ -61,7 +61,7 @@ def build_file_tree(root_path, ignore_patterns=None):
     """Build a tree representing the file structure."""
     if ignore_patterns is None:
         base_patterns = ['.git', '__pycache__', '*.pyc', '.DS_Store', '.idea', '.vscode']
-        global_path = Path('~/.gitignore_global')
+        global_path = Path('~/.gitignore_global').expanduser()
         global_patterns = read_globs(global_path, base_patterns)
         local_path = Path(root_path) / '.gitignore'
         local_patterns = read_globs(local_path, base_patterns)


### PR DESCRIPTION
### **User description**
Also ignore any globs found in `./.gitignore` and `~/.gitignore_global`


___

### **PR Type**
enhancement


___

### **Description**
- Added functionality to read and process `.gitignore` and `~/.gitignore_global`.

- Enhanced file tree building to incorporate ignore patterns from `.gitignore` files.

- Introduced helper functions `read_non_comments` and `read_globs` for processing ignore files.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>codeselect.py</strong><dd><code>Support `.gitignore` and global patterns in file tree</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

codeselect.py

<li>Added <code>read_non_comments</code> to filter non-comment lines from files.<br> <li> Added <code>read_globs</code> to process ignore patterns from <code>.gitignore</code> files.<br> <li> Modified <code>build_file_tree</code> to include <code>.gitignore</code> and global ignore <br>patterns.<br> <li> Enhanced ignore pattern handling with base, global, and local <br>patterns.


</details>


  </td>
  <td><a href="https://github.com/jalanb/codeselect/pull/1/files#diff-dee4ecbfb15baa1a57cefea2937aa4828b6a10a807c0fc88be049f678a148368">+22/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>